### PR TITLE
Hotfix - parameters to json schema - now examples are generated

### DIFF
--- a/example/swagger-files/schema-examples.json
+++ b/example/swagger-files/schema-examples.json
@@ -8,18 +8,16 @@
   "paths": {
     "/v2/customers/": {
       "get": {
-        "summary": "Get a list of customers",
+        "summary": "The most important endpoint with examples",
         "description": "The list can be filtered specifying the following parameters",
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "parameters": [
           {
             "examples": [
               "5f227688780d3e001130daea"
             ],
-            "description": "Hexadecimal identifier of the document in the collection",
-            "required": false,
+            "description": "should be 5f227688780d3e001130daea in generated examples",
+            "required": true,
             "name": "_id",
             "in": "query",
             "schema": {
@@ -29,7 +27,7 @@
           },
           {
             "description": "creatorId",
-            "required": false,
+            "required": true,
             "name": "creatorId",
             "in": "query",
             "schema": {
@@ -37,8 +35,8 @@
             }
           },
           {
-            "description": "createdAt",
-            "required": false,
+            "description": "should be something like this 6719-46-56T24:51:40Z",
+            "required": true,
             "name": "createdAt",
             "in": "query",
             "schema": {
@@ -56,8 +54,8 @@
             }
           },
           {
-            "description": "updatedAt",
-            "required": false,
+            "description": "should be something like this 6719-46-56T24:51:40Z",
+            "required": true,
             "name": "updatedAt",
             "in": "query",
             "schema": {
@@ -66,7 +64,7 @@
             }
           },
           {
-            "required": false,
+            "required": true,
             "name": "name",
             "in": "query",
             "schema": {
@@ -74,7 +72,11 @@
             }
           },
           {
-            "required": false,
+            "examples": [
+              "test.name.surname@email.country"
+            ],
+            "description": "should be 'test.name.surname@email.country' in generated examples",
+            "required": true,
             "name": "email",
             "in": "query",
             "schema": {
@@ -82,7 +84,11 @@
             }
           },
           {
-            "required": false,
+            "examples": [
+              "via calatafimi 10, Milano 20147"
+            ],
+            "description": "should be 'via calatafimi 10, Milano 20147' in generated examples",
+            "required": true,
             "name": "deliveryAddress",
             "in": "query",
             "schema": {
@@ -90,7 +96,11 @@
             }
           },
           {
-            "required": false,
+            "examples": [
+              "3333333333"
+            ],
+            "description": "should be '3333333333' in generated examples",
+            "required": true,
             "name": "phone",
             "in": "query",
             "schema": {
@@ -98,7 +108,11 @@
             }
           },
           {
-            "required": false,
+            "examples": [
+              "rossi", "verdi", "bianchi", "scuri"
+            ],
+            "description": "should be one of \"rossi\", \"verdi\", \"bianchi\", \"scuri\" in generated examples",
+            "required": true,
             "name": "surname",
             "in": "query",
             "schema": {
@@ -106,8 +120,11 @@
             }
           },
           {
-            "description": "Additional query part to forward to MongoDB",
-            "required": false,
+            "examples": [
+              "queryString1"
+            ],
+            "description": "should be 'queryString1' in generated examples",
+            "required": true,
             "name": "_q",
             "in": "query",
             "schema": {
@@ -115,8 +132,8 @@
             }
           },
           {
-            "description": "Return only the properties specified in a comma separated list",
-            "required": false,
+            "description": "should respect this pattern in generated example",
+            "required": true,
             "name": "_p",
             "in": "query",
             "schema": {
@@ -125,8 +142,8 @@
             }
           },
           {
-            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
-            "required": false,
+            "description": "should respect default value 'PUBLIC' in generated example",
+            "required": true,
             "name": "_st",
             "in": "query",
             "schema": {
@@ -136,20 +153,19 @@
             }
           },
           {
-            "description": "Limits the number of documents, max 200 elements, minimum 1",
-            "required": false,
+            "description": "should be a range from 1 to 200 in generated examples",
+            "required": true,
             "name": "_l",
             "in": "query",
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 200,
-              "default": 25
+              "maximum": 200
             }
           },
           {
-            "description": "Skip the specified number of documents",
-            "required": false,
+            "description": "Should respect minimum 0 in generated examples",
+            "required": true,
             "name": "_sk",
             "in": "query",
             "schema": {
@@ -158,8 +174,8 @@
             }
           },
           {
-            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
-            "required": false,
+            "description": "should respect this pattern in generated example",
+            "required": true,
             "name": "_s",
             "in": "query",
             "schema": {

--- a/example/swagger-files/schema-examples.json
+++ b/example/swagger-files/schema-examples.json
@@ -1,91 +1,13326 @@
 {
   "openapi": "3.0.0",
-  "servers": [
-    {
-      "url": "http://example.com"
-    }
-  ],
   "info": {
-    "title": "example results",
-    "version": "1.0"
+    "version": "45bb7eecff08417735ec0009f20bb9d0fd0d60ec",
+    "title": "Platform Development",
+    "description": "Project to try & test feature of the platform\n\n<hr /><a class=\"btn\" href=\"./?swaggerPath=./libri.json\">Libri</a>&emsp;<a class=\"btn\" href=\"./?swaggerPath=./json\">All</a>\n"
   },
   "paths": {
-    "/pets": {
+    "/v2/customers/": {
+      "get": {
+        "summary": "Get a list of customers",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daea"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|deliveryAddress|phone|surname)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130dae9"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "addresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deliveryAddress": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "number"
+                      },
+                      "surname": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
+        "summary": "Add a new item to the customers collection",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body8"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db0a"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the customers collection",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the customers collection that match the query",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daec"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body9"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/export": {
+      "get": {
+        "summary": "Export the customers collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daeb"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|deliveryAddress|phone|surname)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/customers/{id}": {
+      "get": {
+        "summary": "Find one item from the customers collection by ID",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|email|addresses|deliveryAddress|phone|surname)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dae9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deliveryAddress": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number"
+                    },
+                    "surname": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the customers collection",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the customers collection by ID",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body9"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dae9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deliveryAddress": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number"
+                    },
+                    "surname": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the customers collection",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body8"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/count": {
+      "get": {
+        "summary": "Count the number of customers",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daec"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/upsert-one": {
+      "post": {
+        "summary": "Update an item of customers if it is present, otherwise insert it",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "anyOf": [
-                  {
-                    "title": "Pet by Type",
+                "type": "object",
+                "properties": {
+                  "$set": {
                     "type": "object",
                     "properties": {
-                      "pet_type": {
-                        "type": "string",
-                        "examples": ["carlino"]
+                      "name": {
+                        "type": "string"
                       },
-                      "pet_children": {
+                      "email": {
+                        "type": "string"
+                      },
+                      "addresses": {
                         "type": "array",
                         "items": {
-                          "type": "string",
-                          "examples": ["john", "doo"]
+                          "type": "string"
                         }
-                      }
-                    }
-                  },
-                  {
-                    "title": "Pet by Name",
-                    "type": "object",
-                    "examples": [{ "pet_name": "scooby" }],
-                    "properties": {
-                      "pet_name": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  {
-                    "title": "Pet by Address",
-                    "type": "object",
-                    "properties": {
-                      "pet_type": {
+                      },
+                      "deliveryAddress": {
                         "type": "string"
                       },
-                      "pet_country": {
-                        "type": "string",
-                        "examples": ["neverland"]
+                      "phone": {
+                        "type": "number"
+                      },
+                      "surname": {
+                        "type": "string"
+                      },
+                      "addresses.$.replace": {
+                        "type": "string"
                       }
-                    }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "email": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "addresses": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "deliveryAddress": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "phone": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "surname": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {
+                      "phone": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {
+                      "phone": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {
+                      "addresses": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "addresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deliveryAddress": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "number"
+                      },
+                      "surname": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
                   }
-                ]
+                },
+                "additionalProperties": false
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Updated"
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dae9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deliveryAddress": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number"
+                    },
+                    "surname": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/bulk": {
+      "post": {
+        "summary": "Insert new customers",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deliveryAddress": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number"
+                    },
+                    "surname": {
+                      "type": "string"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db0b"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of customers, each one with its own modifications",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db0c"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "deliveryAddress": {
+                          "type": "string"
+                        },
+                        "phone": {
+                          "type": "number"
+                        },
+                        "surname": {
+                          "type": "string"
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            },
+                            "addresses": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deliveryAddress": {
+                              "type": "string"
+                            },
+                            "phone": {
+                              "type": "number"
+                            },
+                            "surname": {
+                              "type": "string"
+                            },
+                            "addresses.$.replace": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "email": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "addresses": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "deliveryAddress": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "phone": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "surname": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {
+                            "phone": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {
+                            "phone": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {
+                            "addresses": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/customers/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of customers",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "deliveryAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/customers/state": {
+      "post": {
+        "summary": "Change state of items of customers",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db0d"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "deliveryAddress": {
+                          "type": "string"
+                        },
+                        "phone": {
+                          "type": "number"
+                        },
+                        "surname": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated customers",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated customers"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/": {
+      "get": {
+        "summary": "Get a list of dishes",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daee"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|price|calories)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130daed"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "ingredients": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "price": {
+                        "type": "number"
+                      },
+                      "calories": {
+                        "type": "number"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new item to the dishes collection",
+        "tags": [
+          "Dishes"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body5"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db0e"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the dishes collection",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the dishes collection that match the query",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf0"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body6"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/export": {
+      "get": {
+        "summary": "Export the dishes collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daef"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|price|calories)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/dishes/{id}": {
+      "get": {
+        "summary": "Find one item from the dishes collection by ID",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|ingredients|price|calories|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daed"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the dishes collection",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the dishes collection by ID",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body6"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daed"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the dishes collection",
+        "tags": [
+          "Dishes"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body5"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/count": {
+      "get": {
+        "summary": "Count the number of dishes",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf0"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/upsert-one": {
+      "post": {
+        "summary": "Update an item of dishes if it is present, otherwise insert it",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "$set": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "ingredients": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "price": {
+                        "type": "number"
+                      },
+                      "calories": {
+                        "type": "number"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "ingredients.$.replace": {
+                        "type": "string"
+                      },
+                      "image.$.replace": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "image.$.merge": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "calories": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "image": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {
+                      "price": {
+                        "type": "number"
+                      },
+                      "calories": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {
+                      "price": {
+                        "type": "number"
+                      },
+                      "calories": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {
+                      "ingredients": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "ingredients": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "price": {
+                        "type": "number"
+                      },
+                      "calories": {
+                        "type": "number"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daed"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/bulk": {
+      "post": {
+        "summary": "Insert new dishes",
+        "tags": [
+          "Dishes"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "ingredients",
+                    "price"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db0f"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of dishes, each one with its own modifications",
+        "tags": [
+          "Dishes"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db10"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "price": {
+                          "type": "number"
+                        },
+                        "calories": {
+                          "type": "number"
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "ingredients": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "price": {
+                              "type": "number"
+                            },
+                            "calories": {
+                              "type": "number"
+                            },
+                            "image": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              }
+                            },
+                            "ingredients.$.replace": {
+                              "type": "string"
+                            },
+                            "image.$.replace": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "image.$.merge": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "calories": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "image": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {
+                            "price": {
+                              "type": "number"
+                            },
+                            "calories": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {
+                            "price": {
+                              "type": "number"
+                            },
+                            "calories": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {
+                            "ingredients": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/dishes/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of dishes",
+        "tags": [
+          "Dishes"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "price",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "calories",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/dishes/state": {
+      "post": {
+        "summary": "Change state of items of dishes",
+        "tags": [
+          "Dishes"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db11"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "price": {
+                          "type": "number"
+                        },
+                        "calories": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated dishes",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated dishes"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/": {
+      "get": {
+        "summary": "Get a list of ingredients",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf2"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130daf1"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new item to the ingredients collection",
+        "tags": [
+          "Ingredients"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body4"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db12"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the ingredients collection",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the ingredients collection that match the query",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf4"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body11"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/export": {
+      "get": {
+        "summary": "Export the ingredients collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf3"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/ingredients/{id}": {
+      "get": {
+        "summary": "Find one item from the ingredients collection by ID",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|name|description|image)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf1"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the ingredients collection",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the ingredients collection by ID",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body11"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf1"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the ingredients collection",
+        "tags": [
+          "Ingredients"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body4"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/count": {
+      "get": {
+        "summary": "Count the number of ingredients",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf4"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/upsert-one": {
+      "post": {
+        "summary": "Update an item of ingredients if it is present, otherwise insert it",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "$set": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "image.$.replace": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "image.$.merge": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "description": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "image": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {
+                      "image": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf1"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/bulk": {
+      "post": {
+        "summary": "Insert new ingredients",
+        "tags": [
+          "Ingredients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db13"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of ingredients, each one with its own modifications",
+        "tags": [
+          "Ingredients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db14"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              }
+                            },
+                            "image.$.replace": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "image.$.merge": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "description": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "image": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {
+                            "image": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/ingredients/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of ingredients",
+        "tags": [
+          "Ingredients"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/ingredients/state": {
+      "post": {
+        "summary": "Change state of items of ingredients",
+        "tags": [
+          "Ingredients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db15"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated ingredients",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated ingredients"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/": {
+      "get": {
+        "summary": "Get a list of mycollection",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf6"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130daf5"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new item to the mycollection collection",
+        "tags": [
+          " Crud"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db16"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the mycollection collection",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the mycollection collection that match the query",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf8"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body3"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/export": {
+      "get": {
+        "summary": "Export the mycollection collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf7"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/.crud/{id}": {
+      "get": {
+        "summary": "Find one item from the mycollection collection by ID",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf5"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the mycollection collection",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the mycollection collection by ID",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body3"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf5"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the mycollection collection",
+        "tags": [
+          " Crud"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/count": {
+      "get": {
+        "summary": "Count the number of mycollection",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130daf8"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/upsert-one": {
+      "post": {
+        "summary": "Update an item of mycollection if it is present, otherwise insert it",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "$set": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf5"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/bulk": {
+      "post": {
+        "summary": "Insert new mycollection",
+        "tags": [
+          " Crud"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db17"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of mycollection, each one with its own modifications",
+        "tags": [
+          " Crud"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db18"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/.crud/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of mycollection",
+        "tags": [
+          " Crud"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/.crud/state": {
+      "post": {
+        "summary": "Change state of items of mycollection",
+        "tags": [
+          " Crud"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db19"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated mycollection",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated mycollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/": {
+      "get": {
+        "summary": "Get a list of orders",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130dafc"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130dafb"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|riderId|totalPrice|address|isLate|status|orderedAt)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130daf9"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      },
+                      "dishes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "riderId": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130dafa"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      },
+                      "totalPrice": {
+                        "type": "number"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "isLate": {
+                        "type": "boolean"
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                      },
+                      "orderedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new item to the orders collection",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body7"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227689780d3e001130db1a"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the orders collection",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the orders collection that match the query",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db05"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body12"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/export": {
+      "get": {
+        "summary": "Export the orders collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130dafd"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130dafe"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|riderId|totalPrice|address|isLate|status|orderedAt)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/orders/{id}": {
+      "get": {
+        "summary": "Find one item from the orders collection by ID",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130daff"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|dishes|riderId|totalPrice|address|isLate|status|orderedAt)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "dishes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "riderId": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dafa"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    },
+                    "totalPrice": {
+                      "type": "number"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "isLate": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                    },
+                    "orderedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the orders collection",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the orders collection by ID",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body12"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "dishes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "riderId": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dafa"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    },
+                    "totalPrice": {
+                      "type": "number"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "isLate": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                    },
+                    "orderedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the orders collection",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body7"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/count": {
+      "get": {
+        "summary": "Count the number of orders",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db05"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/upsert-one": {
+      "post": {
+        "summary": "Update an item of orders if it is present, otherwise insert it",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "$set": {
+                    "type": "object",
+                    "properties": {
+                      "dishes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "riderId": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db02"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      },
+                      "totalPrice": {
+                        "type": "number"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "isLate": {
+                        "type": "boolean"
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                      },
+                      "orderedAt": {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                        "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                      },
+                      "dishes.$.replace": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "dishes.$.merge": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {
+                      "isLate": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {
+                      "totalPrice": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {
+                      "totalPrice": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {
+                      "orderedAt": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {
+                      "dishes": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {
+                      "dishes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "riderId": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db03"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      },
+                      "totalPrice": {
+                        "type": "number"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "isLate": {
+                        "type": "boolean"
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                      },
+                      "orderedAt": {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                        "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130daf9"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "dishes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "riderId": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130dafa"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    },
+                    "totalPrice": {
+                      "type": "number"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "isLate": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                    },
+                    "orderedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/bulk": {
+      "post": {
+        "summary": "Insert new orders",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "dishes",
+                    "riderId",
+                    "totalPrice",
+                    "address",
+                    "status",
+                    "orderedAt"
+                  ],
+                  "properties": {
+                    "dishes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "riderId": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db04"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    },
+                    "totalPrice": {
+                      "type": "number"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "isLate": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                    },
+                    "orderedAt": {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                      "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227689780d3e001130db1b"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of orders, each one with its own modifications",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227689780d3e001130db1c"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "riderId": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db00"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "totalPrice": {
+                          "type": "number"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "isLate": {
+                          "type": "boolean"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                        },
+                        "orderedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {
+                            "dishes": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              }
+                            },
+                            "riderId": {
+                              "type": "string",
+                              "examples": [
+                                "5f227688780d3e001130db01"
+                              ],
+                              "pattern": "^[a-fA-F\\d]{24}$",
+                              "description": "Hexadecimal identifier of the document in the collection"
+                            },
+                            "totalPrice": {
+                              "type": "number"
+                            },
+                            "address": {
+                              "type": "string"
+                            },
+                            "isLate": {
+                              "type": "boolean"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                            },
+                            "orderedAt": {
+                              "type": "string",
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                              "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                            },
+                            "dishes.$.replace": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "dishes.$.merge": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {
+                            "isLate": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {
+                            "totalPrice": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {
+                            "totalPrice": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {
+                            "orderedAt": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {
+                            "dishes": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/orders/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of orders",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "examples": [
+              "5f227688780d3e001130db00"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "riderId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "required": false,
+            "name": "totalPrice",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "required": false,
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "isLate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Order status. One of 'preparing', 'delivered', 'arrived'",
+            "required": false,
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6",
+            "required": false,
+            "name": "orderedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/orders/state": {
+      "post": {
+        "summary": "Change state of items of orders",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227689780d3e001130db1d"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "riderId": {
+                          "type": "string",
+                          "examples": [
+                            "5f227688780d3e001130db00"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "totalPrice": {
+                          "type": "number"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "isLate": {
+                          "type": "boolean"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                        },
+                        "orderedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated orders",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated orders"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/": {
+      "get": {
+        "summary": "Get a list of riders",
+        "description": "The list can be filtered specifying the following parameters",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db07"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents, max 200 elements, minimum 1",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|trasportType)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227688780d3e001130db06"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "_id"
+                      },
+                      "creatorId": {
+                        "type": "string",
+                        "description": "creatorId"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "createdAt"
+                      },
+                      "updaterId": {
+                        "type": "string",
+                        "description": "updaterId"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "updatedAt"
+                      },
+                      "__STATE__": {
+                        "type": "string",
+                        "description": "__STATE__"
+                      },
+                      "surname": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "number",
+                        "description": "phone number"
+                      },
+                      "ratings": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      },
+                      "position": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      },
+                      "trasportType": {
+                        "type": "string",
+                        "description": "Es: bike, scooter, car, etc..."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new item to the riders collection",
+        "tags": [
+          "Riders"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body13"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227689780d3e001130db1e"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete items from the riders collection",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the items of the riders collection that match the query",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db09"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body14"
+        },
+        "responses": {
+          "200": {
+            "description": "the number of documents that were modified",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "number",
+                  "description": "the number of documents that were modified"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/export": {
+      "get": {
+        "summary": "Export the riders collection",
+        "description": "The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db08"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "Limits the number of documents",
+            "required": false,
+            "name": "_l",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "description": "Skip the specified number of documents",
+            "required": false,
+            "name": "_sk",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "description": "Sort by the specified property (Start with a \"-\" to invert the sort order)",
+            "required": false,
+            "name": "_s",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|trasportType)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/riders/{id}": {
+      "get": {
+        "summary": "Find one item from the riders collection by ID",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only the properties specified in a comma separated list",
+            "required": false,
+            "name": "_p",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^((_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType),)*(_id|creatorId|createdAt|updaterId|updatedAt|__STATE__|surname|name|email|phone|ratings|position|trasportType)$"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db06"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "surname": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number",
+                      "description": "phone number"
+                    },
+                    "ratings": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "position": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "trasportType": {
+                      "type": "string",
+                      "description": "Es: bike, scooter, car, etc..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item from the riders collection",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an item of the riders collection by ID",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body14"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db06"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "surname": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number",
+                      "description": "phone number"
+                    },
+                    "ratings": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "position": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "trasportType": {
+                      "type": "string",
+                      "description": "Es: bike, scooter, car, etc..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/validate": {
+      "post": {
+        "summary": "Return 200 if the body is valid for an insertion in the riders collection",
+        "tags": [
+          "Riders"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body13"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/count": {
+      "get": {
+        "summary": "Count the number of riders",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "examples": [
+              "5f227688780d3e001130db09"
+            ],
+            "description": "Hexadecimal identifier of the document in the collection",
+            "required": false,
+            "name": "_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-fA-F\\d]{24}$"
+            }
+          },
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/upsert-one": {
+      "post": {
+        "summary": "Update an item of riders if it is present, otherwise insert it",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list",
+            "required": false,
+            "name": "_st",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+              "default": "PUBLIC"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "$set": {
+                    "type": "object",
+                    "properties": {
+                      "surname": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "number",
+                        "description": "phone number"
+                      },
+                      "ratings": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      },
+                      "position": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 3
+                      },
+                      "trasportType": {
+                        "type": "string",
+                        "description": "Es: bike, scooter, car, etc..."
+                      },
+                      "ratings.$.replace": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$unset": {
+                    "type": "object",
+                    "properties": {
+                      "surname": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "name": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "email": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "phone": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "ratings": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "position": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      },
+                      "trasportType": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$inc": {
+                    "type": "object",
+                    "properties": {
+                      "phone": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$mul": {
+                    "type": "object",
+                    "properties": {
+                      "phone": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$currentDate": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  },
+                  "$push": {
+                    "type": "object",
+                    "properties": {
+                      "ratings": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "$setOnInsert": {
+                    "type": "object",
+                    "properties": {
+                      "surname": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "number",
+                        "description": "phone number"
+                      },
+                      "ratings": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      },
+                      "position": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 3
+                      },
+                      "trasportType": {
+                        "type": "string",
+                        "description": "Es: bike, scooter, car, etc..."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db06"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "_id"
+                    },
+                    "creatorId": {
+                      "type": "string",
+                      "description": "creatorId"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "createdAt"
+                    },
+                    "updaterId": {
+                      "type": "string",
+                      "description": "updaterId"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "updatedAt"
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "description": "__STATE__"
+                    },
+                    "surname": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number",
+                      "description": "phone number"
+                    },
+                    "ratings": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "position": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "trasportType": {
+                      "type": "string",
+                      "description": "Es: bike, scooter, car, etc..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/bulk": {
+      "post": {
+        "summary": "Insert new riders",
+        "tags": [
+          "Riders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "surname": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number",
+                      "description": "phone number"
+                    },
+                    "ratings": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "position": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 3
+                    },
+                    "trasportType": {
+                      "type": "string",
+                      "description": "Es: bike, scooter, car, etc..."
+                    },
+                    "__STATE__": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ],
+                      "description": "The state of the document",
+                      "default": "DRAFT"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "examples": [
+                          "5f227689780d3e001130db1f"
+                        ],
+                        "pattern": "^[a-fA-F\\d]{24}$",
+                        "description": "Hexadecimal identifier of the document in the collection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update multiple items of riders, each one with its own modifications",
+        "tags": [
+          "Riders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227689780d3e001130db20"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "_st": {
+                          "type": "string",
+                          "pattern": "(PUBLIC|DRAFT|TRASH|DELETED)(,(PUBLIC|DRAFT|TRASH|DELETED))*",
+                          "default": "PUBLIC",
+                          "description": "Filter by \\_\\_STATE__, multiple states can be specified in OR by providing a comma separated list"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "surname": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "phone": {
+                          "type": "number",
+                          "description": "phone number"
+                        },
+                        "trasportType": {
+                          "type": "string",
+                          "description": "Es: bike, scooter, car, etc..."
+                        },
+                        "_q": {
+                          "type": "string",
+                          "description": "Additional query part to forward to MongoDB"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "update": {
+                      "type": "object",
+                      "properties": {
+                        "$set": {
+                          "type": "object",
+                          "properties": {
+                            "surname": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            },
+                            "phone": {
+                              "type": "number",
+                              "description": "phone number"
+                            },
+                            "ratings": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              }
+                            },
+                            "position": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 3
+                            },
+                            "trasportType": {
+                              "type": "string",
+                              "description": "Es: bike, scooter, car, etc..."
+                            },
+                            "ratings.$.replace": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$unset": {
+                          "type": "object",
+                          "properties": {
+                            "surname": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "name": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "email": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "phone": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "ratings": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "position": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            },
+                            "trasportType": {
+                              "type": "boolean",
+                              "enum": [
+                                true
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$inc": {
+                          "type": "object",
+                          "properties": {
+                            "phone": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$mul": {
+                          "type": "object",
+                          "properties": {
+                            "phone": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "$currentDate": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        },
+                        "$push": {
+                          "type": "object",
+                          "properties": {
+                            "ratings": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "update"
+                  ]
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/riders/{id}/state": {
+      "post": {
+        "summary": "Change state of an item of riders",
+        "tags": [
+          "Riders"
+        ],
+        "parameters": [
+          {
+            "description": "creatorId",
+            "required": false,
+            "name": "creatorId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "createdAt",
+            "required": false,
+            "name": "createdAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "description": "updaterId",
+            "required": false,
+            "name": "updaterId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "updatedAt",
+            "required": false,
+            "name": "updatedAt",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$"
+            }
+          },
+          {
+            "required": false,
+            "name": "surname",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "required": false,
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "phone number",
+            "required": false,
+            "name": "phone",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Es: bike, scooter, car, etc...",
+            "required": false,
+            "name": "trasportType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Additional query part to forward to MongoDB",
+            "required": false,
+            "name": "_q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the doc _id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body10"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/riders/state": {
+      "post": {
+        "summary": "Change state of items of riders",
+        "tags": [
+          "Riders"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "filter": {
+                      "type": "object",
+                      "required": [
+                        "_id"
+                      ],
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "examples": [
+                            "5f227689780d3e001130db21"
+                          ],
+                          "pattern": "^[a-fA-F\\d]{24}$",
+                          "description": "Hexadecimal identifier of the document in the collection"
+                        },
+                        "creatorId": {
+                          "type": "string",
+                          "description": "creatorId"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "createdAt"
+                        },
+                        "updaterId": {
+                          "type": "string",
+                          "description": "updaterId"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                          "description": "updatedAt"
+                        },
+                        "surname": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "phone": {
+                          "type": "number",
+                          "description": "phone number"
+                        },
+                        "trasportType": {
+                          "type": "string",
+                          "description": "Es: bike, scooter, car, etc..."
+                        }
+                      }
+                    },
+                    "stateTo": {
+                      "type": "string",
+                      "enum": [
+                        "PUBLIC",
+                        "DRAFT",
+                        "TRASH",
+                        "DELETED"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "filter",
+                    "stateTo"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of updated riders",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of updated riders"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/join/one-to-one/{from}/{to}/export": {
+      "post": {
+        "tags": [
+          "CRUD Join"
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body15"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/join/one-to-one/{from}/{to}/": {
+      "post": {
+        "tags": [
+          "CRUD Join"
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body15"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/join/one-to-many/{from}/{to}/export": {
+      "post": {
+        "tags": [
+          "CRUD Join"
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body2"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v2/join/many-to-many/{from}/{to}/export": {
+      "post": {
+        "tags": [
+          "CRUD Join"
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Body2"
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
           }
         }
       }
     }
   },
   "components": {
-    "schemas": {},
-    "responses": {},
-    "parameters": {},
-    "examples": {},
-    "requestBodies": {},
-    "securitySchemes": {},
-    "headers": {}
+    "securitySchemes": {
+      "APISecretHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "secret"
+      }
+    },
+    "requestBodies": {
+      "Body": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body2": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "asField",
+                "localField",
+                "foreignField"
+              ],
+              "properties": {
+                "fromQueryFilter": {
+                  "type": "object",
+                  "default": {}
+                },
+                "toQueryFilter": {
+                  "type": "object",
+                  "default": {}
+                },
+                "asField": {
+                  "type": "string"
+                },
+                "localField": {
+                  "type": "string"
+                },
+                "foreignField": {
+                  "type": "string"
+                },
+                "fromProjectBefore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "fromProjectAfter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "toProjectBefore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "toProjectAfter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body3": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body4": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "image": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body5": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "name",
+                "ingredients",
+                "price"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "ingredients": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "price": {
+                  "type": "number"
+                },
+                "calories": {
+                  "type": "number"
+                },
+                "image": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body6": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "ingredients.$.replace": {
+                      "type": "string"
+                    },
+                    "image.$.replace": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "image.$.merge": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "calories": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "image": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {
+                    "price": {
+                      "type": "number"
+                    },
+                    "calories": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {
+                    "ingredients": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body7": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "dishes",
+                "riderId",
+                "totalPrice",
+                "address",
+                "status",
+                "orderedAt"
+              ],
+              "properties": {
+                "dishes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "riderId": {
+                  "type": "string",
+                  "examples": [
+                    "5f227688780d3e001130db04"
+                  ],
+                  "pattern": "^[a-fA-F\\d]{24}$",
+                  "description": "Hexadecimal identifier of the document in the collection"
+                },
+                "totalPrice": {
+                  "type": "number"
+                },
+                "address": {
+                  "type": "string"
+                },
+                "isLate": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                },
+                "orderedAt": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                  "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                },
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body8": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "addresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deliveryAddress": {
+                  "type": "string"
+                },
+                "phone": {
+                  "type": "number"
+                },
+                "surname": {
+                  "type": "string"
+                },
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body9": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deliveryAddress": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number"
+                    },
+                    "surname": {
+                      "type": "string"
+                    },
+                    "addresses.$.replace": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "email": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "addresses": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "deliveryAddress": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "phone": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "surname": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {
+                    "phone": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {
+                    "phone": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {
+                    "addresses": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body10": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "stateTo"
+              ],
+              "properties": {
+                "stateTo": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "TRASH",
+                    "DRAFT",
+                    "DELETED"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "Body11": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "image.$.replace": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "image.$.merge": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "description": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "image": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body12": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {
+                    "dishes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "riderId": {
+                      "type": "string",
+                      "examples": [
+                        "5f227688780d3e001130db01"
+                      ],
+                      "pattern": "^[a-fA-F\\d]{24}$",
+                      "description": "Hexadecimal identifier of the document in the collection"
+                    },
+                    "totalPrice": {
+                      "type": "number"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "isLate": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Order status. One of 'preparing', 'delivered', 'arrived'"
+                    },
+                    "orderedAt": {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2}))?$",
+                      "description": "\"date-time\" according with https://tools.ietf.org/html/rfc3339#section-5.6"
+                    },
+                    "dishes.$.replace": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "dishes.$.merge": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {
+                    "isLate": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {
+                    "totalPrice": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {
+                    "totalPrice": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {
+                    "orderedAt": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {
+                    "dishes": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body13": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "surname": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "phone": {
+                  "type": "number",
+                  "description": "phone number"
+                },
+                "ratings": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "position": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 3
+                },
+                "trasportType": {
+                  "type": "string",
+                  "description": "Es: bike, scooter, car, etc..."
+                },
+                "__STATE__": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "DRAFT",
+                    "TRASH",
+                    "DELETED"
+                  ],
+                  "description": "The state of the document",
+                  "default": "DRAFT"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body14": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "$set": {
+                  "type": "object",
+                  "properties": {
+                    "surname": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "number",
+                      "description": "phone number"
+                    },
+                    "ratings": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "position": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 3
+                    },
+                    "trasportType": {
+                      "type": "string",
+                      "description": "Es: bike, scooter, car, etc..."
+                    },
+                    "ratings.$.replace": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$unset": {
+                  "type": "object",
+                  "properties": {
+                    "surname": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "name": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "email": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "phone": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "ratings": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "position": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "trasportType": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$inc": {
+                  "type": "object",
+                  "properties": {
+                    "phone": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$mul": {
+                  "type": "object",
+                  "properties": {
+                    "phone": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "$currentDate": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "$push": {
+                  "type": "object",
+                  "properties": {
+                    "ratings": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "Body15": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "asField",
+                "localField",
+                "foreignField"
+              ],
+              "properties": {
+                "fromQueryFilter": {
+                  "type": "object",
+                  "default": {}
+                },
+                "toQueryFilter": {
+                  "type": "object",
+                  "default": {}
+                },
+                "asField": {
+                  "type": "string"
+                },
+                "localField": {
+                  "type": "string"
+                },
+                "foreignField": {
+                  "type": "string"
+                },
+                "fromProjectBefore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "fromProjectAfter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "toProjectBefore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "toProjectAfter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "toMerge": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
   },
-  "x-explorer-enabled": true,
-  "x-samples-enabled": true,
-  "x-samples-languages": [
-    "curl",
-    "node",
-    "ruby",
-    "javascript",
-    "python"
-  ]
+  "tags": []
 }

--- a/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/api-explorer/__tests__/lib/parameters-to-json-schema.test.js
@@ -300,6 +300,108 @@ test('it should pass through description', () => {
   ]);
 });
 
+test('it should pass through maximum & minimum', () => {
+  expect(
+    parametersToJsonSchema({
+      parameters: [
+        {
+          in: 'body',
+          name: 'number',
+          description: 'number',
+          schema: {
+            type: 'number',
+            maximum: 18,
+            minimum: 10,
+          },
+        },
+      ],
+    }),
+  ).toEqual([
+    {
+      label: 'Body Params',
+      type: 'body',
+      schema: {
+        type: 'object',
+        required: [],
+        properties: {
+          number: {
+            description: 'number',
+            type: 'number',
+            maximum: 18,
+            minimum: 10,
+          }
+        }
+      },
+    },
+  ]);
+})
+test('it should pass through examples', () => {
+  expect(
+    parametersToJsonSchema({
+      parameters: [
+        {
+          in: 'body',
+          name: 'number',
+          description: 'number',
+          examples: [ 15 ],
+          schema: {
+            type: 'number',
+          },
+        },
+      ],
+    }),
+  ).toEqual([
+    {
+      label: 'Body Params',
+      type: 'body',
+      schema: {
+        type: 'object',
+        required: [],
+        properties: {
+          number: {
+            description: 'number',
+            type: 'number',
+            examples: [ 15 ],
+          }
+        }
+      },
+    },
+  ]);
+})
+test('it should pass through pattern', () => {
+  expect(
+    parametersToJsonSchema({
+      parameters: [
+        {
+          in: 'body',
+          name: 'number',
+          description: 'number',
+          schema: {
+            type: 'number',
+            pattern: '[0-9]{2}$',
+          },
+        },
+      ],
+    }),
+  ).toEqual([
+    {
+      label: 'Body Params',
+      type: 'body',
+      schema: {
+        type: 'object',
+        required: [],
+        properties: {
+          number: {
+            description: 'number',
+            type: 'number',
+            pattern: '[0-9]{2}$',
+          }
+        }
+      },
+    },
+  ]);
+});
+
 test('it should work for top-level request body $ref', () => {
   expect(
     parametersToJsonSchema(
@@ -377,8 +479,6 @@ test('it should pull out schemas from `components/requestBodies`', () => {
     },
   ]);
 });
-
-test.skip('it should make things required correctly', () => {});
 
 test('it should pass false value as default parameter', () => {
   expect(

--- a/packages/api-explorer/src/components/SchemaTabs/index.jsx
+++ b/packages/api-explorer/src/components/SchemaTabs/index.jsx
@@ -79,7 +79,6 @@ export default class SchemaTabs extends Component {
 
   componentDidMount() {
     const { operation, oas } = this.props
-    console.log('parametersToJsonSchema(operation, oas)', parametersToJsonSchema(operation, oas))
     const schema = get(parametersToJsonSchema(operation, oas), '[0].schema', {})
     refParser.dereference(resolveRootRef(schema), (err, schemaResolved) => {
       if (!err) {

--- a/packages/api-explorer/src/components/SchemaTabs/index.jsx
+++ b/packages/api-explorer/src/components/SchemaTabs/index.jsx
@@ -79,6 +79,7 @@ export default class SchemaTabs extends Component {
 
   componentDidMount() {
     const { operation, oas } = this.props
+    console.log('parametersToJsonSchema(operation, oas)', parametersToJsonSchema(operation, oas))
     const schema = get(parametersToJsonSchema(operation, oas), '[0].schema', {})
     refParser.dereference(resolveRootRef(schema), (err, schemaResolved) => {
       if (!err) {

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -94,8 +94,6 @@ module.exports = (pathOperation, oas) => {
 
   if (!hasParameters && !hasRequestBody) return null;
 
-  console.log('getBodyParam(pathOperation, oas', getBodyParam(pathOperation, oas))
-  console.log('getOtherParams(pathOperation, oas', getOtherParams(pathOperation, oas))
   return [getBodyParam(pathOperation, oas)]
     .concat(...getOtherParams(pathOperation, oas))
     .filter(Boolean);

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -63,7 +63,6 @@ function getOtherParams(pathOperation, oas) {
         if (current.schema.pattern) schema.pattern = current.schema.pattern;
         if (current.schema.minimum) schema.minimum = current.schema.minimum;
         if (current.schema.maximum) schema.maximum = current.schema.maximum;
-        if (current.schema.pattern) schema.pattern = current.schema.pattern;
         if (current.examples) schema.examples = current.examples;
       }
 

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -61,6 +61,9 @@ function getOtherParams(pathOperation, oas) {
         if (current.schema.type) schema.type = current.schema.type;
         if (current.schema.format) schema.format = current.schema.format;
         if (current.schema.pattern) schema.pattern = current.schema.pattern;
+        if (current.schema.minimum) schema.minimum = current.schema.minimum;
+        if (current.schema.maximum) schema.maximum = current.schema.maximum;
+        if (current.schema.pattern) schema.pattern = current.schema.pattern;
         if (current.examples) schema.examples = current.examples;
       }
 

--- a/packages/api-explorer/src/lib/parameters-to-json-schema.js
+++ b/packages/api-explorer/src/lib/parameters-to-json-schema.js
@@ -47,7 +47,7 @@ function getOtherParams(pathOperation, oas) {
     if (parameters.length === 0) return null;
 
     const properties = parameters.reduce((prev, current) => {
-      const schema = { type: 'string' };
+      const schema = {type: 'string'};
 
       if (current.description) schema.description = current.description;
 
@@ -56,11 +56,12 @@ function getOtherParams(pathOperation, oas) {
           schema.type = 'array';
           schema.items = current.schema.items;
         }
-
         if (typeof current.schema.default !== 'undefined') schema.default = current.schema.default;
         if (current.schema.enum) schema.enum = current.schema.enum;
         if (current.schema.type) schema.type = current.schema.type;
         if (current.schema.format) schema.format = current.schema.format;
+        if (current.schema.pattern) schema.pattern = current.schema.pattern;
+        if (current.examples) schema.examples = current.examples;
       }
 
       prev[current.name] = schema;
@@ -90,6 +91,8 @@ module.exports = (pathOperation, oas) => {
 
   if (!hasParameters && !hasRequestBody) return null;
 
+  console.log('getBodyParam(pathOperation, oas', getBodyParam(pathOperation, oas))
+  console.log('getOtherParams(pathOperation, oas', getOtherParams(pathOperation, oas))
   return [getBodyParam(pathOperation, oas)]
     .concat(...getOtherParams(pathOperation, oas))
     .filter(Boolean);


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

#### 📄 Description
Despite evolution of crud-service, the examples key was not considered in the schema generated inside "parametersToJsonSchema.js". With key "examples", "minimum", "maximum" and "pattern" are also excluded inside of the method "getOtherParams".

#### 📹 GIF
![hotfix-api-explorer](https://user-images.githubusercontent.com/22480239/88928295-f4038000-d278-11ea-917a-c50e22ec7915.gif)

#### ✅ Checklist
- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [ ] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
