### PR TITLE
FIX(BMP-454): white background for JSONForm title bugfix

### DIFF
--- a/packages/api-explorer/src/JsonForm/configureJsonEditor.js
+++ b/packages/api-explorer/src/JsonForm/configureJsonEditor.js
@@ -24,6 +24,7 @@ function setDefaultCustomization (JSONEditor) {
           this.editjson_textcontainer.style.height = '36px'
           this.editjson_textcontainer.style.padding = '0px'
           this.editjson_textcontainer.style.border = '0px'
+          this.editjson_textcontainer.style.backgroundColor = 'inherit'
           this.editjson_text = document.createElement('label')
           this.editjson_text.innerHTML = 'Edit JSON'
           this.editjson_text.style.verticalAlign = 'middle'


### PR DESCRIPTION
There was a white background around the title of the JSONForm:
![whitebackbug](https://user-images.githubusercontent.com/32339431/89025298-df7dc100-d326-11ea-85c0-b4d06a9bf816.png)

  
After the fix it looks like this:

![bugfix](https://user-images.githubusercontent.com/32339431/89025649-7fd3e580-d327-11ea-95f4-188061bb964c.png)


#### Checklist

[BMP-454](https://makeitapp.atlassian.net/browse/BMP-454)

- [ ] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [ ] the changelog has been updated accordingly with your changes
- [X] you are not committing extraneous files or sensible data
- [X] added the link to the Jira task
- [X] commit message and branch name conventions

#### Notify to

<!-- Tag people here -->